### PR TITLE
Fix histogram issues

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -37,7 +37,7 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Upload pytest test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
           name: pytest-results-${{ matrix.python-version }}
           path: junit/test-results-${{ matrix.python-version }}.xml

--- a/carabiner/mpl/utils.py
+++ b/carabiner/mpl/utils.py
@@ -226,14 +226,19 @@ def scattergrid(
                          if xscale == "log":
                               values = group_df.query(f"{grid_col_name} > 0")[grid_col_name].values
                               values = values[np.isfinite(values)]
-                              values_min, values_max = values.min(), values.max()
-                              if values_min == values_max:
-                                   hist_max = hist_min + 1.
-                              bins = np.geomspace(
-                                   values_min, 
-                                   hist_max, 
-                                   num=n_bins,
-                              )
+                              if values.size > 0:
+                                   values_min, values_max = values.min(), values.max()
+                                   if values_min == values_max:
+                                        hist_max = values_min + 1.
+                                   else:
+                                        hist_max = values_max
+                                   bins = np.geomspace(
+                                        values_min, 
+                                        hist_max, 
+                                        num=n_bins,
+                                   )
+                              else:
+                                  continue 
                          else:
                               bins = n_bins
                          try:

--- a/carabiner/mpl/utils.py
+++ b/carabiner/mpl/utils.py
@@ -224,7 +224,7 @@ def scattergrid(
                     labels = {"label": ":".join(map(str, group_name))} if not dummy_group else {}
                     if make_histogram:
                          if xscale == "log":
-                              values = group_df.query(f"{grid_col_name} > 0")[grid_col_name].values
+                              values = group_df.query(f"`{grid_col_name}` > 0")[grid_col_name].values
                               values = values[np.isfinite(values)]
                               if values.size > 0:
                                    values_min, values_max = values.min(), values.max()

--- a/carabiner/mpl/utils.py
+++ b/carabiner/mpl/utils.py
@@ -224,21 +224,28 @@ def scattergrid(
                     labels = {"label": ":".join(map(str, group_name))} if not dummy_group else {}
                     if make_histogram:
                          if xscale == "log":
-                              values = group_df[grid_col_name].values
+                              values = group_df.query(f"{grid_col_name} > 0")[grid_col_name].values
+                              values = values[np.isfinite(values)]
+                              values_min, values_max = values.min(), values.max()
+                              if values_min == values_max:
+                                   hist_max = hist_min + 1.
                               bins = np.geomspace(
-                                   values.min(), 
-                                   values.max(), 
+                                   values_min, 
+                                   hist_max, 
                                    num=n_bins,
                               )
                          else:
                               bins = n_bins
-                         ax.hist(
-                              grid_col_name, 
-                              data=group_df, 
-                              bins=bins,
-                              **_hist_opts,
-                              **labels,
-                         )
+                         try:
+                              ax.hist(
+                                   grid_col_name, 
+                                   data=group_df, 
+                                   bins=bins,
+                                   **_hist_opts,
+                                   **labels,
+                              )
+                         except ValueError as e:  # Usually some problem with value ranges, but shouldn't prevent plotting
+                              print_err(e)
                     else:
                          ax.scatter(
                               grid_col_name,


### PR DESCRIPTION
Plotting a log histogram in `scattergrid()` was failing in the presence of zeros or infinite values in one panel, causing the whole plot to fail. In these cases, the zeros and non-finite values are filtered out, and other `ValueError`s are caught to allow the rest of the plot to proceed.