### PR TITLE
Fixes and improvements for v0.0.5

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
-name: Python package
+name: Python tests
 
 on:
   [push]

--- a/carabiner/mpl/utils.py
+++ b/carabiner/mpl/utils.py
@@ -239,6 +239,7 @@ def scattergrid(
      fig, axes = grid(
           nrow=len(grid_rows), 
           ncol=len(grid_columns),
+          squeeze=False,
           *args, **kwargs
      )
      for axrow, grid_row_name in zip(tqdm(axes), grid_rows):

--- a/carabiner/mpl/utils.py
+++ b/carabiner/mpl/utils.py
@@ -302,7 +302,7 @@ def figsaver(
      output_dir: str = ".",
      prefix: Optional[str] = None,
      dpi: int = 300, 
-     format: str = 'png', 
+     format: Union[str, Iterable[str]] = "png", 
 ) -> Callable[[figure.Figure, str, int, str, Optional[DataFrame]], None]:
 
      """Create a function to save figures in a predefined location.
@@ -315,8 +315,8 @@ def figsaver(
           Prefix for filenames. Default: no prefix.
      dpi : int, optional
           Resolution of saved figures. Default: 300.
-     format : str, optional
-          File format of figures. Default: "png".
+     format : str or Iterable, optional
+          File format(s) of figures. Default: "png".
 
      Returns
      -------
@@ -331,6 +331,11 @@ def figsaver(
      if not os.path.exists(output_dir):
           os.mkdir(output_dir)
 
+     if isinstance(format, str):
+          format = [format]
+     if isinstance(format, tuple):
+          format = list(format)
+
      def _figsave(
           fig: figure.Figure, 
           name: str, 
@@ -339,13 +344,14 @@ def figsaver(
           """
 
           """
-          figname = os.path.join(output_dir, f"{prefix}{name}.{format}")
-          print_err(f"Saving plot at {figname}")
-          fig.savefig(
-               figname, 
-               dpi=dpi, 
-               bbox_inches='tight',
-          )
+          for _format in format:
+               figname = os.path.join(output_dir, f"{prefix}{name}.{_format}")
+               print_err(f"Saving plot at {figname}")
+               fig.savefig(
+                    figname, 
+                    dpi=dpi, 
+                    bbox_inches="tight",
+               )
           if df is not None and isinstance(df, DataFrame):
                dataname = os.path.join(output_dir, f"{prefix}{name}.csv")
                print_err(f"Saving data at {dataname}")

--- a/carabiner/mpl/utils.py
+++ b/carabiner/mpl/utils.py
@@ -26,6 +26,15 @@ colorblind_palette = utils_colorblind_palette
 
 # Set default color cycle on import
 rcParams['axes.prop_cycle'] = cycler(color=colorblind_palette())
+from matplotlib import rcParams
+rcParams['font.sans-serif'] = [
+    "Nimbus Sans",
+    "Helvetica",
+    "Arial",
+    "DejaVu Sans",
+    "FreeSans",
+    "sans-serif"
+]
 
 def grid(
      nrow: int = 1, 

--- a/carabiner/mpl/utils.py
+++ b/carabiner/mpl/utils.py
@@ -229,9 +229,18 @@ def scattergrid(
           df = df.groupby(grouping)
           dummy_group = False
 
-     _scatter_opts = {"s": 3.}
+     _scatter_opts = {"s": 5., "facecolor": "none", "linewidth": 1.}
      _scatter_opts.update(scatter_opts or {})
-     _hist_opts = {"alpha": .7} if not dummy_group else {}
+     _hist_opts = {
+          "alpha": .7, 
+          "linewidth": 1., 
+          "histtype": "stepfilled",
+          "edgecolor": "lightgrey",
+     } 
+     if dummy_group:
+          _hist_opts.update({
+               "alpha": 1., 
+          })
      _hist_opts.update(hist_opts or {})
      _legend_opts = {}
      _legend_opts.update(legend_opts or {})
@@ -248,7 +257,8 @@ def scattergrid(
                xscale = "log" if grid_col_name in log else "linear"
                yscale = "log" if (grid_row_name in log and not make_histogram) else "linear"
                ylabel = grid_row_name if not make_histogram else "Frequency"
-               for group_name, group_df in df:
+               color = f"C{i}"
+               for i, (group_name, group_df) in enumerate(df):
                     labels = {"label": ":".join(map(str, group_name))} if not dummy_group else {}
                     if make_histogram:
                          if xscale == "log":
@@ -274,6 +284,7 @@ def scattergrid(
                                    grid_col_name, 
                                    data=group_df, 
                                    bins=bins,
+                                   fill=color,
                                    **_hist_opts,
                                    **labels,
                               )
@@ -283,7 +294,8 @@ def scattergrid(
                          ax.scatter(
                               grid_col_name,
                               grid_row_name, 
-                              data=group_df, 
+                              data=group_df,
+                              edgecolor=color,
                               **_scatter_opts,
                               **labels,
                          )

--- a/carabiner/mpl/utils.py
+++ b/carabiner/mpl/utils.py
@@ -256,7 +256,12 @@ def scattergrid(
                make_histogram = grid_row_name == grid_col_name
                xscale = "log" if grid_col_name in log else "linear"
                yscale = "log" if (grid_row_name in log and not make_histogram) else "linear"
-               ylabel = grid_row_name if not make_histogram else "Frequency"
+               if not make_histogram:
+                    ylabel = grid_row_name
+               elif hist_opts.get("density", False):
+                    ylabel = "Density"
+               else: 
+                    ylabel = "Frequency"
                for i, (group_name, group_df) in enumerate(df):
                     color = f"C{i}"
                     labels = {"label": ":".join(map(str, group_name))} if not dummy_group else {}

--- a/carabiner/mpl/utils.py
+++ b/carabiner/mpl/utils.py
@@ -257,8 +257,8 @@ def scattergrid(
                xscale = "log" if grid_col_name in log else "linear"
                yscale = "log" if (grid_row_name in log and not make_histogram) else "linear"
                ylabel = grid_row_name if not make_histogram else "Frequency"
-               color = f"C{i}"
                for i, (group_name, group_df) in enumerate(df):
+                    color = f"C{i}"
                     labels = {"label": ":".join(map(str, group_name))} if not dummy_group else {}
                     if make_histogram:
                          if xscale == "log":

--- a/carabiner/mpl/utils.py
+++ b/carabiner/mpl/utils.py
@@ -1,6 +1,6 @@
 """Utilities for matplotlib."""
 
-from typing import Any, Callable, Iterable, Mapping, Tuple, Optional, Union
+from typing import Any, Callable, Iterable, Mapping, Tuple, List, Optional, Union
 from functools import wraps
 import os
 
@@ -18,23 +18,41 @@ else:
 from tqdm.auto import tqdm
 
 from ..cast import cast
-from ..utils import colorblind_palette as utils_colorblind_palette, print_err
+from ..utils import TOL_PALETTES, colorblind_palette as utils_colorblind_palette, print_err
 
 TFigAx = Tuple[figure.Figure, axes.Axes]
 
 colorblind_palette = utils_colorblind_palette
 
 # Set default color cycle on import
-rcParams['axes.prop_cycle'] = cycler(color=colorblind_palette())
+rcParams["axes.prop_cycle"] = cycler(color=colorblind_palette())
 from matplotlib import rcParams
-rcParams['font.sans-serif'] = [
-    "Nimbus Sans",
-    "Helvetica",
-    "Arial",
-    "DejaVu Sans",
-    "FreeSans",
-    "sans-serif"
+rcParams["font.sans-serif"] = [
+    "Nimbus Sans",  # widely available, free
+    "Helvetica",    # available on MacOS
+    "Arial",        # available on Windows
+    "DejaVu Sans",  # available on Linux, mpl default
+    "FreeSans",     # widely available, free
+    "sans-serif",   # system default
 ]
+
+def set_plot_palette(palette: Union[str, Iterable[str]]) -> Tuple[str]:
+     if isinstance(palette, str):
+          if palette in TOL_PALETTES:
+               palette = colorblind_palette(name=palette)
+          else:
+               raise ValueError(f"Palette named '{palette}' not built-in. Try one of {', '.join(TOL_PALETTES)}.")
+     rcParams["axes.prop_cycle"] = cycler(color=palette)
+     return palette
+
+
+def set_plot_font(font: str, category: str = "sans-serif") -> List[str]:
+     valid_categories = ("sans-serif", "serif")
+     if category not in valid_categories:
+          raise ValueError(f"Invalid font category: {category}. Try one of {', '.join(valid_categories)}.")
+     rcParams[f"font.{category}"] = [font] + [f for f in rcParams[f"font.{category}"] if f != font]
+     return rcParams[f"font.{category}"]
+
 
 def grid(
      nrow: int = 1, 

--- a/carabiner/utils.py
+++ b/carabiner/utils.py
@@ -2,7 +2,6 @@
 
 from typing import Any, Iterable, Mapping, Tuple, Optional
 
-from functools import singledispatch
 from itertools import chain
 
 import sys
@@ -103,42 +102,21 @@ def colorblind_palette(
     """
 
     return _colorblind_palette(i=i, name=name)
-    
 
-@singledispatch
+
 def _colorblind_palette(
     i: Any,
     name: str = DEFAULT_PALETTE
-):
+) -> Tuple[str]:
     pal = TOL_PALETTES.get(name, TOL_PALETTES[DEFAULT_PALETTE])
-    try:
+    if i is None:
+        return pal
+    if isinstance(i, Iterable):
         return tuple(pal[j] for j in i)
-    except:
+    elif isinstance(i, (slice, int)):
+        return pal[i]
+    else:
         raise NotImplementedError(f"No method for colorblind_palette for type {type(i)}: {i}.")
-    
-
-@_colorblind_palette.register
-def _(
-    i: None,
-    name: str = DEFAULT_PALETTE
-) -> Tuple[str]:
-    return TOL_PALETTES.get(name, TOL_PALETTES[DEFAULT_PALETTE])
-
-
-@_colorblind_palette.register
-def _(
-    i: slice,
-    name: str = DEFAULT_PALETTE
-) -> Tuple[str]:
-    return TOL_PALETTES.get(name, TOL_PALETTES[DEFAULT_PALETTE])[i]
-
-
-@_colorblind_palette.register
-def _(
-    i: int,
-    name: str = DEFAULT_PALETTE
-) -> Tuple[str]:
-    return TOL_PALETTES.get(name, TOL_PALETTES[DEFAULT_PALETTE])[i]
 
 
 def print_err(*args, **kwargs) -> None:

--- a/carabiner/utils.py
+++ b/carabiner/utils.py
@@ -93,7 +93,7 @@ def colorblind_palette(
     >>> colorblind_palette(range(2))
     ('#0077BB', '#33BBEE')
     >>> colorblind_palette(slice(3, 6))
-    ('#EE7733', '#CC3311', '#EE7733')
+    ('#EE7733', '#CC3311', '#EE3377')
     >>> colorblind_palette(name="vibrant_0")
     ('#EE7733', '#0077BB', '#33BBEE', '#EE3377', '#CC3311', '#009988', '#BBBBBB', '#000000')
     >>> colorblind_palette(name="muted")

--- a/carabiner/utils.py
+++ b/carabiner/utils.py
@@ -89,22 +89,26 @@ def colorblind_palette(
     
     Examples
     --------
-    >>> colorblind_palette(range(2))
+    >>> colorblind_palette(range(2), name="vibrant_0")
     ('#EE7733', '#0077BB')
+    >>> colorblind_palette(range(2))
+    ('#0077BB', '#33BBEE')
     >>> colorblind_palette(slice(3, 6))
-    ('#EE3377', '#CC3311', '#009988')
-    >>> colorblind_palette()
+    ('#EE7733', '#CC3311', '#EE7733')
+    >>> colorblind_palette(name="vibrant_0")
     ('#EE7733', '#0077BB', '#33BBEE', '#EE3377', '#CC3311', '#009988', '#BBBBBB', '#000000')
+    >>> colorblind_palette(name="muted")
+    ('#332288', '#88CCEE', '#44AA99', '#117733', '#999933', '#DDCC77', '#CC6677', '#882255', '#AA4499', '#DDDDDD')
     
     """
 
-    return _colorblind_palette(i)
+    return _colorblind_palette(i=i, name=name)
     
 
 @singledispatch
 def _colorblind_palette(
     i: Any,
-    name: str
+    name: str = DEFAULT_PALETTE
 ):
     pal = TOL_PALETTES.get(name, TOL_PALETTES[DEFAULT_PALETTE])
     try:
@@ -116,7 +120,7 @@ def _colorblind_palette(
 @_colorblind_palette.register
 def _(
     i: None,
-    name: str
+    name: str = DEFAULT_PALETTE
 ) -> Tuple[str]:
     return TOL_PALETTES.get(name, TOL_PALETTES[DEFAULT_PALETTE])
 
@@ -124,7 +128,7 @@ def _(
 @_colorblind_palette.register
 def _(
     i: slice,
-    name: str
+    name: str = DEFAULT_PALETTE
 ) -> Tuple[str]:
     return TOL_PALETTES.get(name, TOL_PALETTES[DEFAULT_PALETTE])[i]
 
@@ -132,7 +136,7 @@ def _(
 @_colorblind_palette.register
 def _(
     i: int,
-    name: str
+    name: str = DEFAULT_PALETTE
 ) -> Tuple[str]:
     return TOL_PALETTES.get(name, TOL_PALETTES[DEFAULT_PALETTE])[i]
 

--- a/carabiner/utils.py
+++ b/carabiner/utils.py
@@ -9,13 +9,68 @@ import sys
 
 __all__ = ["colorblind_palette", "print_err", "pprint_dict", "upper_and_lower"]
 
-_CBPAL = ('#EE7733', '#0077BB', '#33BBEE', 
-          '#EE3377', '#CC3311', '#009988', 
-          '#BBBBBB', "#000000")
+TOL_PALETTES = {
+    "vibrant": (
+        "#0077BB", 
+        "#33BBEE", 
+        "#009988", 
+        "#EE7733", 
+        "#CC3311", 
+        "#EE3377", 
+        "#BBBBBB", 
+        "#000000",
+    ),
+    "vibrant_0": (
+        "#EE7733", 
+        "#0077BB", 
+        "#33BBEE", 
+        "#EE3377", 
+        "#CC3311", 
+        "#009988", 
+        "#BBBBBB", 
+        "#000000",
+    ),
+    "muted": (
+        "#332288",
+        "#88CCEE",
+        "#44AA99",
+        "#117733",
+        "#999933",
+        "#DDCC77",
+        "#CC6677",
+        "#882255",
+        "#AA4499",
+        "#DDDDDD",
+    ),
+    "bright": (
+        "#4477AA",
+        "#66CCEE",
+        "#228833",
+        "#CCBB44",
+        "#EE6677",
+        "#AA3377",
+        "#BBBBBB",
+    ),
+    "medium contrast": (
+        "#FFFFFF",
+        "#EECC66",
+        "#EE99AA",
+        "#6699CC",
+        "#997700",
+        "#994455",
+        "#004488",
+        "#000000",
+    )
+}
 
-def colorblind_palette(i: Optional[Any] = None) -> Tuple[str]:
+DEFAULT_PALETTE = "vibrant"
 
-    """Provide hexadecimal codes for a colorblind-friendly qualitative palette.
+def colorblind_palette(
+    i: Optional[Any] = None,
+    name: str = DEFAULT_PALETTE
+) -> Tuple[str]:
+
+    """Provide hexadecimal codes for Tol's colorblind-friendly qualitative palette.
 
     Parameters
     ----------
@@ -47,30 +102,39 @@ def colorblind_palette(i: Optional[Any] = None) -> Tuple[str]:
     
 
 @singledispatch
-def _colorblind_palette(i: Any):
-    
+def _colorblind_palette(
+    i: Any,
+    name: str
+):
+    pal = TOL_PALETTES.get(name, TOL_PALETTES[DEFAULT_PALETTE])
     try:
-        return tuple(_CBPAL[j] for j in i)
+        return tuple(pal[j] for j in i)
     except:
         raise NotImplementedError(f"No method for colorblind_palette for type {type(i)}: {i}.")
     
 
 @_colorblind_palette.register
-def _(i: None) -> Tuple[str]:
-
-    return _CBPAL
-
-
-@_colorblind_palette.register
-def _(i: slice) -> Tuple[str]:
-
-    return _CBPAL[i]
+def _(
+    i: None,
+    name: str
+) -> Tuple[str]:
+    return TOL_PALETTES.get(name, TOL_PALETTES[DEFAULT_PALETTE])
 
 
 @_colorblind_palette.register
-def _(i: int) -> Tuple[str]:
+def _(
+    i: slice,
+    name: str
+) -> Tuple[str]:
+    return TOL_PALETTES.get(name, TOL_PALETTES[DEFAULT_PALETTE])[i]
 
-    return _CBPAL[i]
+
+@_colorblind_palette.register
+def _(
+    i: int,
+    name: str
+) -> Tuple[str]:
+    return TOL_PALETTES.get(name, TOL_PALETTES[DEFAULT_PALETTE])[i]
 
 
 def print_err(*args, **kwargs) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "carabiner-tools"
-version = "0.0.4"
+version = "0.0.5"
 authors = [
   { name="Eachan Johnson", email="eachan.johnson@crick.ac.uk" },
 ]
@@ -25,6 +25,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3 :: Only",
 ]
 


### PR DESCRIPTION
Fixes:
- Scattergrid now allows one-row or one-column grids, fixes #9 
- Add tests for py3.13

Improvements:
- Functions `set_plot_palette` and `set_plot_font` to adjust matplotlib defaults easily
- Expanded range of colorblind palettes. Tol's vibrant is now the default. The old default palette is now accessed with `colorblind_palette(name="vibrant_0")`
- Scattergrid histogram and scatter uses styles that work better with overplotting.